### PR TITLE
Add connected node setting.

### DIFF
--- a/src/app/components/settings/settings.component.html
+++ b/src/app/components/settings/settings.component.html
@@ -42,6 +42,34 @@
   </div>
 </div>
 
+<!-- Spirit trees -->
+<div class="sky-card mt">
+  <div class="sky-card-header">
+    <h1 class="h2 mb-0">
+      <mat-icon style="transform:scaleY(-1)">network_node</mat-icon>
+      Spirit trees
+    </h1>
+  </div>
+  <div class="sky-card-body">
+    <div class="container">
+      <p>
+        @if (unlockConnectedNodes) {
+          All the items leading up to the item you unlock in a spirit tree will also be unlocked.<br/>
+          Likewise, when you lock an item the items beyond it will be locked. You can disable this here.
+        } @else {
+          When you unlock an item in a spirit tree only that item will be unlocked.<br/>
+          You can choose to also unlock all preceding items below.
+        }
+      </p>
+      <div class="sky-flex flex-wrap mt">
+        <button (click)="toggleConnectedNodes()">
+          <mat-icon class="menu-icon">{{unlockConnectedNodes ? 'check_box' : 'check_box_outline_blank'}}</mat-icon>
+          <span class="menu-label">Unlock connected items</span>
+        </button>
+    </div>
+  </div>
+</div>
+
 <!-- Date -->
 <div class="sky-card mt">
   <div class="sky-card-header">

--- a/src/app/components/settings/settings.component.ts
+++ b/src/app/components/settings/settings.component.ts
@@ -26,6 +26,7 @@ interface IExport {
 })
 export class SettingsComponent {
   storageProviderName: string;
+  unlockConnectedNodes: boolean;
   today = DateTime.now();
   dateFormat: string;
   dateFormats: Array<string>;
@@ -52,6 +53,9 @@ export class SettingsComponent {
     this.dateFormat = DateHelper.displayFormat;
     this.wikiNewTab = _settingService.wikiNewTab;
     this.currentTheme = localStorage.getItem('theme') || '';
+    // TODO: this.unlockConnectedNodes = _storageService.getKey('tree.unlock-connected') !== '0';
+    // TODO: Also use this setting in the new NodeComponent code.
+    this.unlockConnectedNodes = localStorage.getItem('tree.unlock-connected') !== '0';
   }
 
   import(): void {
@@ -79,7 +83,6 @@ export class SettingsComponent {
     };
     input.click();
   }
-
 
   handleImportJson(data: IExport): void {
     if (!data) { throw new Error('No content.'); }
@@ -155,6 +158,12 @@ export class SettingsComponent {
       wingedLights: new Set(),
       favourites: new Set()
     });
+  }
+
+  toggleConnectedNodes(): void {
+    // TODO: _storageService.setKey('tree.unlock-connected', !this.unlockConnectedNodes ? '1' : '0')
+    this.unlockConnectedNodes = !this.unlockConnectedNodes;
+    localStorage.setItem('tree.unlock-connected', this.unlockConnectedNodes ? '1' : '0');
   }
 
   setDateFormat(format: string): void {


### PR DESCRIPTION
For https://github.com/Silverfeelin/SkyGame-Planner/pull/96

Because your branch doesn't contain the StorageService.setKey changes that I merged a bit earlier I have added some TODO comments. If I pulled master then this PR would show all those unrelated changes ><.  
The localStorage version would work fine but the StorageService allows this setting to be saved to the cloud (Dropbox integration).

This change adds a new setting to the Settings page that will (after solving the TODOs) make this preference available through `_storageService.getKey('tree.unlock-connected') !== '0';`. This makes the default enabled even if the setting was never changed.

![image](https://github.com/PlutoyDev/SkyGame-Planner/assets/17196309/a992708d-887d-4226-8ea5-4af3a988a6b7)
